### PR TITLE
fix(zip-import): treat SVG files as images

### DIFF
--- a/packages/healy-utility/lib/importer/import-from-zip.js
+++ b/packages/healy-utility/lib/importer/import-from-zip.js
@@ -83,7 +83,8 @@ async function ingestZip({zipPath, lastModified, originalName}) {
 					entry.fileName.endsWith('.jpg') ||
 					entry.fileName.endsWith('.jpeg') ||
 					entry.fileName.endsWith('.webp') ||
-					entry.fileName.endsWith('.gif')) {
+					entry.fileName.endsWith('.gif') ||
+					entry.filename.endsWith('.svg')) {
 					cacheImageFromZip(entry, readStream).then(() => {
 						zipfile.readEntry();
 					}).catch(error => {


### PR DESCRIPTION
Without this, SVGs would be ignored when importing from a zip file.