### PR TITLE
fix(cache-server): serve images with the correct content-type header

### DIFF
--- a/packages/healy-utility/lib/cache/add-to-cache.js
+++ b/packages/healy-utility/lib/cache/add-to-cache.js
@@ -6,7 +6,7 @@ const cacache = require('cacache');
 // Ours
 const cachePath = require('./cache-path');
 
-module.exports = async function (buffer, {key, fileName, hash, folder, hashAlgorithm = 'md5', processor}) {
+module.exports = async function (buffer, {key, fileName, fileType, hash, folder, hashAlgorithm = 'md5', processor}) {
 	if (!Buffer.isBuffer(buffer)) {
 		throw new Error(`Argument "buffer" must be of type "buffer", got a(n) "${typeof buffer}"`);
 	} else if (typeof fileName !== 'string') {
@@ -44,6 +44,7 @@ module.exports = async function (buffer, {key, fileName, hash, folder, hashAlgor
 			hash,
 			hashAlgorithm,
 			fileName,
+			fileType,
 			folder
 		}
 	};

--- a/packages/healy-utility/lib/importer/import-from-gdrive.js
+++ b/packages/healy-utility/lib/importer/import-from-gdrive.js
@@ -119,6 +119,7 @@ function cacheProjectImagesFromGoogleDrive(project) {
 				}).then(buffer => {
 					return addToCache(buffer, {
 						fileName: metadata.id,
+						fileType: metadata.extension,
 						folder: job.folder,
 						hash: metadata.md5,
 						processor: job.processor

--- a/packages/healy-utility/lib/importer/import-from-zip.js
+++ b/packages/healy-utility/lib/importer/import-from-zip.js
@@ -127,6 +127,7 @@ async function cacheImageFromZip(entry, readStream) {
 			const {buffer, hash} = await streamToBuffer(readStream);
 			return addToCache(buffer, {
 				fileName: entry.fileName,
+				fileType: entry.fileName.split('.').pop(),
 				folder: bottomFolder,
 				hash,
 				processor


### PR DESCRIPTION
Until now, we have not bothered setting the `content-type` header when serving images from the cache. This was because I thought we didn't need to -- browsers seemed to handle our images just fine.

It turns out that browsers are pickier with SVG images though, and they will not display an SVG unless it is served with the `image/svg+xml` content-type header.

This PR updates the `cache-server` to use `express`' lovely `res.type()` method, which can automatically determine the correct value to set for the `content-header` cache based on a file extension. See its docs in full here: https://expressjs.com/en/api.html#res.type

A nice side benefit of this change is that we now serve _all_ images with the correct `content-type`, not just SVGs. I don't think this will affect much, but being "more correct" usually doesn't hurt.