### PR TITLE
fix(errors): fix error summary not working

### DIFF
--- a/packages/healy-utility/lib/importer/project-import.js
+++ b/packages/healy-utility/lib/importer/project-import.js
@@ -255,9 +255,7 @@ function handleProjectImport(project) {
 		replicant.validationErrors.forEach(error => {
 			const field = error.field.replace(/^data\./, '');
 			const columnName = calcColumnName(field);
-			const culpritObject = error.type === 'object' ?
-				objectPath.get(newValue, field.split('.')) :
-				objectPath.get(newValue, field.split('.').slice(0, -1));
+			const culpritObject = objectPath.get(newValue, field.split('.').slice(0, -1));
 			const primaryKeyName = getPrimaryKey(culpritObject);
 
 			const errorReport = {

--- a/packages/healy-utility/schemas/errors.json
+++ b/packages/healy-utility/schemas/errors.json
@@ -47,11 +47,16 @@
 								"type": "string"
 							}, {
 								"type": "array",
-								"items": "string"
+								"items": {
+									"type": "string"
+								}
 							}]
 						},
 						"field": {
 							"type": "string"
+						},
+						"schemaPath": {
+							"type": "array"
 						}
 					}
 				}


### PR DESCRIPTION
Due to a dependency update in NodeCG core itself, the error reporting functionality of Healy (the bit of the UI which enumerates all the individual Validation Errors from the sheet) hasn't been working. This commit get it to work in at least some cases again. There will likely be more work to do to get it working in all cases once again.